### PR TITLE
Issue36 fix the export function in comment history page

### DIFF
--- a/app/templates/comment_history.html
+++ b/app/templates/comment_history.html
@@ -169,7 +169,7 @@ block styles %}
       );
       const csvContent =
         "data:text/csv;charset=utf-8," +
-        encodeURI(generateCSVContent(filteredRows));
+        encodeURIComponent(generateCSVContent(filteredRows));
 
       const link = document.createElement("a");
       link.href = csvContent;
@@ -197,9 +197,6 @@ block styles %}
                 let fullComment = cell
                   .querySelector(".read-details-btn")
                   .getAttribute("data-comment");
-
-                // Replace any '#' with the string '(hash)' to avoiding commenting out the rest of the comment
-                fullComment = fullComment.replace(/#/g, "(hash)");
 
                 // Wrap the comment inside double quotes, escaping any internal double quotes
                 // For addressing the issue of comments containing commas that would otherwise be interpreted as a delimiter

--- a/app/templates/comment_history.html
+++ b/app/templates/comment_history.html
@@ -179,17 +179,41 @@ block styles %}
 
     // Function to generate CSV content from table rows
     function generateCSVContent(rows) {
+      // Get all headers from the table, exclude the last header (Action) and then wrap each header text inside double quotes, escaping any internal double quotes
       const headers = Array.from(document.querySelectorAll(".comment-list th"))
-        .slice(0, -1) // Exclude the last header (Action)
-        .map((header) => header.textContent);
+        .slice(0, -1)
+        .map((header) => `"${header.textContent.replace(/"/g, '""')}"`);
 
-      const rowsContent = rows.map((row) =>
-        Array.from(row.querySelectorAll("td"))
-          .slice(0, -1) // Exclude the last column (View Workload button)
-          .map((cell) => cell.textContent)
-          .join(",")
+      // For each row in the table
+      const rowsContent = rows.map(
+        (row) =>
+          // Get all table data cells, exclude the last cell (View Workload button)
+          Array.from(row.querySelectorAll("td"))
+            .slice(0, -1)
+            .map((cell, index) => {
+              // If the current cell is the comment cell
+              if (index === 1) {
+                // Get the full comment stored in the data attribute of the button
+                let fullComment = cell
+                  .querySelector(".read-details-btn")
+                  .getAttribute("data-comment");
+
+                // Replace any '#' with the string '(hash)' to avoiding commenting out the rest of the comment
+                fullComment = fullComment.replace(/#/g, "(hash)");
+
+                // Wrap the comment inside double quotes, escaping any internal double quotes
+                // For addressing the issue of comments containing commas that would otherwise be interpreted as a delimiter
+                return `"${fullComment.replace(/"/g, '""')}"`;
+              }
+
+              // For all other cells, wrap the text inside double quotes, escaping any internal double quotes
+              // For addressing the issue of comments containing commas that would otherwise be interpreted as a delimiter
+              return `"${cell.textContent.replace(/"/g, '""')}"`;
+            })
+            .join(",") // Join all the cells for a row with commas
       );
 
+      // Join all the rows with a newline and return the content
       return [headers.join(","), ...rowsContent].join("\n");
     }
 


### PR DESCRIPTION
## Change Summary 📝
Revise the CSV generation logic to handle special characters (e.g. comma, hash) in comment content to ensure the export csv file is in order.

---

## Change Form 📋
Please mark as NA if not applicable. If a certain criterion is not met, kindly provide a reason.

- [x] The pull request title has an issue number.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [ ] Relevant tests (if applicable) have been added or updated.

---

## Any background context you want to provide? 🖼️

Before:
<img width="409" alt="image" src="https://github.com/yylocky/CITS5206-Group3/assets/116782485/e255b076-07e1-45ba-b899-a92070421154">

After:
<img width="946" alt="image" src="https://github.com/yylocky/CITS5206-Group3/assets/116782485/6e8212e0-8e97-45e8-9a1b-ce29b22e0698">

## Reviewers 🕵️

(Optional) Suggest reviewers that might be interested in this PR.
